### PR TITLE
Add missing use GoogleApi\Client;

### DIFF
--- a/src/GoogleApi/Contrib/apiAdexchangebuyerService.php
+++ b/src/GoogleApi/Contrib/apiAdexchangebuyerService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiAdsenseService.php
+++ b/src/GoogleApi/Contrib/apiAdsenseService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiAdsensehostService.php
+++ b/src/GoogleApi/Contrib/apiAdsensehostService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiBigqueryService.php
+++ b/src/GoogleApi/Contrib/apiBigqueryService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiBloggerService.php
+++ b/src/GoogleApi/Contrib/apiBloggerService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiBooksService.php
+++ b/src/GoogleApi/Contrib/apiBooksService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiCalendarService.php
+++ b/src/GoogleApi/Contrib/apiCalendarService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiCustomsearchService.php
+++ b/src/GoogleApi/Contrib/apiCustomsearchService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiDriveService.php
+++ b/src/GoogleApi/Contrib/apiDriveService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiFreebaseService.php
+++ b/src/GoogleApi/Contrib/apiFreebaseService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiGanService.php
+++ b/src/GoogleApi/Contrib/apiGanService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiGroupssettingsService.php
+++ b/src/GoogleApi/Contrib/apiGroupssettingsService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiLatitudeService.php
+++ b/src/GoogleApi/Contrib/apiLatitudeService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiModeratorService.php
+++ b/src/GoogleApi/Contrib/apiModeratorService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiOauth2Service.php
+++ b/src/GoogleApi/Contrib/apiOauth2Service.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiOrkutService.php
+++ b/src/GoogleApi/Contrib/apiOrkutService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiPagespeedonlineService.php
+++ b/src/GoogleApi/Contrib/apiPagespeedonlineService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiPlusService.php
+++ b/src/GoogleApi/Contrib/apiPlusService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiPredictionService.php
+++ b/src/GoogleApi/Contrib/apiPredictionService.php
@@ -17,10 +17,10 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;
-use GoogleApi\Client;
 
   /**
    * The "trainedmodels" collection of methods.

--- a/src/GoogleApi/Contrib/apiShoppingService.php
+++ b/src/GoogleApi/Contrib/apiShoppingService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiSiteVerificationService.php
+++ b/src/GoogleApi/Contrib/apiSiteVerificationService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiTasksService.php
+++ b/src/GoogleApi/Contrib/apiTasksService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiTranslateService.php
+++ b/src/GoogleApi/Contrib/apiTranslateService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiUrlshortenerService.php
+++ b/src/GoogleApi/Contrib/apiUrlshortenerService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;

--- a/src/GoogleApi/Contrib/apiWebfontsService.php
+++ b/src/GoogleApi/Contrib/apiWebfontsService.php
@@ -17,6 +17,7 @@
 
 namespace GoogleApi\Contrib;
 
+use GoogleApi\Client;
 use GoogleApi\Service\Model;
 use GoogleApi\Service\Service;
 use GoogleApi\Service\ServiceResource;


### PR DESCRIPTION
A lot of code is currently not working because it needs:

 use GoogleApi\Client;

in the top of the files.
