### PR TITLE
Fix problem with Model class

### DIFF
--- a/src/GoogleApi/Service/Model.php
+++ b/src/GoogleApi/Service/Model.php
@@ -93,7 +93,7 @@ class Model {
    * @return object The object from the item.
    */
   private function createObjectFromName($name, $item) {
-    $type = $this->$name;
+    $type = '\GoogleApi\Contrib\\' . $this->$name;
     return new $type($item);
   }
 


### PR DESCRIPTION
If the namespace is not specified PHP throws a fatal error.
