### PR TITLE
HttpRequest: use relative url path.

### DIFF
--- a/src/GoogleApi/Io/HttpRequest.php
+++ b/src/GoogleApi/Io/HttpRequest.php
@@ -45,7 +45,7 @@ class HttpRequest {
   protected $responseHttpCode;
   protected $responseHeaders;
   protected $responseBody;
-  
+
   public $accessKey;
 
   public function __construct($url, $method = 'GET', $headers = array(), $postBody = null) {

--- a/src/GoogleApi/Io/HttpRequest.php
+++ b/src/GoogleApi/Io/HttpRequest.php
@@ -195,6 +195,9 @@ class HttpRequest {
     if (substr($url, 0, 4) == 'http') {
       $this->url = $url;
     } else {
+      if (substr($url, 0, 1) !== '/') {
+        $url = '/' . $url;
+      }
       $this->url = Config::get('basePath') . $url;
     }
   }


### PR DESCRIPTION
Use the relative url path. This way we won't have anything like this:

www.googleapis.complaylistitems
